### PR TITLE
livenessProbe docker image: fix mem leak

### DIFF
--- a/aws-ebs/kubernetes/latest/controller.yaml
+++ b/aws-ebs/kubernetes/latest/controller.yaml
@@ -267,7 +267,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: quay.io/k8scsi/livenessprobe:v1.0.1
+          image: quay.io/k8scsi/livenessprobe:v1.0.2
           args:
             - --csi-address=/csi/csi.sock
             - --connection-timeout=3s


### PR DESCRIPTION
In relation to this bug https://github.com/kubernetes-csi/livenessprobe/issues/45, we should upgrade the docker version of the livenessProbe docker image.